### PR TITLE
XPSNR: introduce temporal and verbose parameters

### DIFF
--- a/src/vszip.zig
+++ b/src/vszip.zig
@@ -161,7 +161,7 @@ export fn VapourSynthPluginInit2(plugin: *vs.Plugin, vspapi: *const vs.PLUGINAPI
     );
     _ = vspapi.registerFunction.?(
         xpsnr.filter_name,
-        "reference:vnode;distorted:vnode;",
+        "reference:vnode;distorted:vnode;temporal:int:opt;verbose:int:opt;",
         "clip:vnode;",
         xpsnr.xpsnrCreate,
         null,


### PR DESCRIPTION
Having to see scores being printed in the terminal doesn't make much sense and can be avoided, I introduced a simple `verbose` parameter that defaults to `True` so the original behavior isn't altered.

The temporal component of XPSNR isn't ideal and may be better off disabled for some use cases, the most important of which being when computing scores every X frames using `std.SelectEvery`, which can throw off the results otherwise. VMAF also allows disabling its temporal component (were they aware of how unreliable it is?) and as the one of XPSNR hasn't been demonstrated to be that much better (speed was a greater concern to them), I think it would be nice to allow the user to disable it _if desired_, hence the introduction of a `temporal` parameter. In a way, that makes XPSNR behave more like an image metric like SSIMULACRA2. The temporal component seems to simply increase the score as more motion is detected, so it's not like it should ever be _dangerous_ to disable it. As for `verbose`, the original behavior isn't altered: `temporal` defaults to `True`. I have even observed some speed-ups in orders of 3-6% when using `False`, which has additional appeal IMO.

Feel free to criticize. I didn't document these changes, but I can if you wish.